### PR TITLE
docs: fix typo 'succesfully' -> 'successfully' across TestNet docs

### DIFF
--- a/testnet/smart-contract/deploying.md
+++ b/testnet/smart-contract/deploying.md
@@ -16,7 +16,7 @@ Learn how to deploy a smart contract.
 Note:
 
 #content
-- Ensure your succesfully saved you previously written contract. 
+- Ensure you successfully saved you previously written contract. 
 ::
 
 ## Run the deploy command of qvmctl using docker

--- a/testnet/smart-contract/interacting.md
+++ b/testnet/smart-contract/interacting.md
@@ -16,7 +16,7 @@ Learn how to interact with a smart contract.
 Note:
 
 #content
-- Ensure you succesfully deployed your smart contract.
+- Ensure you successfully deployed your smart contract.
 ::
 
 ## Reading from the database

--- a/testnet/smart-contract/writing/c.md
+++ b/testnet/smart-contract/writing/c.md
@@ -16,7 +16,7 @@ Learn how to write a smart contract in C.
 Note:
 
 #content
-- Ensure you succesfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
+- Ensure you successfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
 ::
 
 ## Sample contract functionality

--- a/testnet/smart-contract/writing/cpp.md
+++ b/testnet/smart-contract/writing/cpp.md
@@ -16,7 +16,7 @@ Learn how to write a smart contract in C++.
 Note:
 
 #content
-- Ensure you succesfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
+- Ensure you successfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
 ::
 
 ## Sample contract functionality

--- a/testnet/smart-contract/writing/go.md
+++ b/testnet/smart-contract/writing/go.md
@@ -16,7 +16,7 @@ Learn how to write a smart contract in Golang (Go).
 Note:
 
 #content
-- Ensure you succesfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
+- Ensure you successfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
 ::
 
 ## Sample contract functionality

--- a/testnet/smart-contract/writing/javascript.md
+++ b/testnet/smart-contract/writing/javascript.md
@@ -16,7 +16,7 @@ Learn how to write a smart contract in JavaScript (JS).
 Note:
 
 #content
-- Ensure you succesfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl). 
+- Ensure you successfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl). 
 ::
 
 ## Sample contract functionality

--- a/testnet/smart-contract/writing/solidity.md
+++ b/testnet/smart-contract/writing/solidity.md
@@ -16,7 +16,7 @@ Learn how to write a smart contract in Solidity.
 Note:
 
 #content
-- Ensure you succesfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl). 
+- Ensure you successfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl). 
 ::
 
 ## Sample contract functionality

--- a/testnet/smart-contract/writing/typescript.md
+++ b/testnet/smart-contract/writing/typescript.md
@@ -16,7 +16,7 @@ Learn how to write a smart contract in TypeScript (TS).
 Note:
 
 #content
-- Ensure you succesfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
+- Ensure you successfully [set up your dev environment](/testnet/smart-contract/setup/qvmctl).
 ::
 
 ## Sample contract functionality


### PR DESCRIPTION
Corrects the misspelling “**succesfully**” to “**successfully**” in documentation.
